### PR TITLE
Fixed ‘dict_values’ Not Subscriptable in the keyboard_retrieval.py, updated README.md, and updated chattering_fix.service

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo pip3 install -r requirements.txt
 
 ## Usage
 
-cd inside the location of the KeyboardChatteringFix-Linux extracted folder and enter the command below to run.
+`cd` inside the location of the KeyboardChatteringFix-Linux-master extracted folder and enter the command below to run.
 
 ```shell
 sudo python3 -m src
@@ -74,8 +74,28 @@ sudo python3 -m src
 ## Automation
 
 Starting the script manually every time doesn't sound like the greatest idea, so
-you should probably consider something that does it for you. The solution I provide
-is a systemd unit file, `chattering_fix.service`. Copy it to `/etc/systemd/system/`, then enable it with
-`systemctl enable --now chattering_fix`. Don't forget to change the command inside `ExecStart` to
-tell the service what id your keyboard has and where the script is located. The script
-should be executable as well.
+you should probably consider something that does it for you. Modify the `chattering_fix.sh` to `cd` into the absolute path of the downloaded folder and input the keyboard id and the desired threshold. For example:
+```shell
+cd /home/foouser/Downloads/KeyboardChatteringFix-Linux-master/ && sudo python3 -m src -k usb-SINO_WEALTH_USB_KEYBOARD-event-kbd -t 50
+```
+Also, make sure to change the file permission of `chattering_fix.sh` so that it is executable.
+```shell
+chmod +x chattering_fix.sh
+```
+The `chattering_fix.service` file should also be edited. The `ExecStart` should be the absolute path of the `chattering_fix.sh`. For example:
+```shell
+ExecStart=/home/foouser/Downloads/KeyboardChatteringFix-Linux-master/chattering_fix.sh
+```
+Then, copy the `chattering_fix.service` to `/etc/systemd/system/` and enable it with the command below.
+```shell
+systemctl enable --now chattering_fix
+```
+You can check if the systemd unit file is properly working using 
+```shell
+systemctl status chattering_fix.service
+```
+You can also use 
+```shell
+journalctl -xeu chattering_fix.service
+```
+just to make sure that there are no errors.

--- a/README.md
+++ b/README.md
@@ -43,12 +43,18 @@ By filtering such anomalies, we can hopefully remove chatter without impeding ac
 
 ## Installation
 
-Clone the repository and install the required dependencies enlisted in `requirements.txt`.
+Download the repository as zip and extract the file. The dependencies are listed in the requirements.txt. You can install it with the command below. 
+
+```shell
+sudo pip3 install -r requirements.txt
+```
 
 ## Usage
 
+cd inside the location of the KeyboardChatteringFix-Linux extracted folder and enter the command below to run.
+
 ```shell
-sudo <path-to-python-executable> -m src
+sudo python3 -m src
 ```
 
 ### Customization Options

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ By filtering such anomalies, we can hopefully remove chatter without impeding ac
 
 ## Installation
 
-Download the repository as zip and extract the file. The dependencies are listed in the requirements.txt. You can install it with the command below. 
+Download the repository as a zip and extract the file. The dependencies are listed in the requirements.txt. And you can install it with the command below. 
 
 ```shell
 sudo pip3 install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sudo python3 -m src
 
 Starting the script manually every time doesn't sound like the greatest idea, so
 you should probably consider something that does it for you. The solution I provide
-is a systemd unit file. Copy it to `/etc/systemd/system/`, then enable it with
-`systemctl enable --now chattering_fix`. Don't forget to change the command inside to
+is a systemd unit file, `chattering_fix.service`. Copy it to `/etc/systemd/system/`, then enable it with
+`systemctl enable --now chattering_fix`. Don't forget to change the command inside `ExecStart` to
 tell the service what id your keyboard has and where the script is located. The script
 should be executable as well.

--- a/chattering_fix.service
+++ b/chattering_fix.service
@@ -2,8 +2,9 @@
 Description=Keyboard Chattering Fix service
 
 [Service]
-Restart=on-failure
-ExecStart=cd <path-to-repo-root> && sudo python3 -m src
+ExecStart=cd <path/to/file> && sudo python3 -m src
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target

--- a/chattering_fix.service
+++ b/chattering_fix.service
@@ -2,7 +2,9 @@
 Description=Keyboard Chattering Fix service
 
 [Service]
-ExecStart=cd <path/to/file> && sudo python3 -m src
+# Change ExecStart to the absolute path of the file, executing chattering_fix.sh
+ExecStart=<absolute/path/to/file/chattering_fix.sh>
+
 Restart=always
 RestartSec=5
 

--- a/chattering_fix.service
+++ b/chattering_fix.service
@@ -3,7 +3,7 @@ Description=Keyboard Chattering Fix service
 
 [Service]
 Restart=on-failure
-ExecStart=cd <path-to-repo-root> && sudo <path-to-python-executable> -m src
+ExecStart=cd <path-to-repo-root> && sudo python3 -m src
 
 [Install]
 WantedBy=multi-user.target

--- a/chattering_fix.sh
+++ b/chattering_fix.sh
@@ -1,0 +1,3 @@
+#!bin/bash
+# Change the line below to the absolute path of the folder
+cd <absolute/path/to/folder> && sudo python3 -m src -k <KEYBOARD id> -t <OPTIONAL, 30 is the default threshold>

--- a/src/keyboard_retrieval.py
+++ b/src/keyboard_retrieval.py
@@ -17,15 +17,16 @@ def retrieve_keyboard_name() -> str:
     if n_devices == 1:
         logging.info(f"Found keyboard: {keyboard_devices[0]}")
         return keyboard_devices[0]
-    return inquirer.prompt(
+    keyboard_value = list(inquirer.prompt(
         questions=[
             inquirer.List(
                 '_',
                 message='Select a device',
                 choices=keyboard_devices,
-            ),
+            )
         ]
-    ).values()[0]
+    ).values())
+    return keyboard_value[0]
 
 
 def abs_keyboard_path(device: str) -> str:


### PR DESCRIPTION
Major update:
- Fixed keyboard_retrieval.py where if you just run it without -k <keyboard_name>, an error message will pop up.
- Fixed chattering_fix.service when keyboard is unplugged then plugged, the service fails and does not restart.
- Added chattering_fix.sh because there are errors saying "cd: no such file or directory" even with the use of absolute path.

Minor update:
- Added more instructions on installation, usage, and automation so that it is easier to follow