### PR TITLE
Open keyboard file if available else exit

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -13,6 +13,11 @@ from src.keyboard_retrieval import retrieve_keyboard_name, INPUT_DEVICES_PATH, a
 def get_device_handle(keyboard_name: str) -> libevdev.Device:
     """ Safely get an evdev device handle. """
 
+    # check if the device exists by checking if the device path exists
+    if not os.path.exists(abs_keyboard_path(keyboard_name)):
+        logging.critical(f"Keyboard device {keyboard_name} not connected.")
+        sys.exit(0)
+
     fd = open(abs_keyboard_path(keyboard_name), 'rb')
     evdev = libevdev.Device(fd)
     try:


### PR DESCRIPTION
### Why 
My keyboard chatter issue in external keyboard but not in built-in laptop keyboard. It KeyboardChatteringFix was working fine when I had external keyboard attached. But when I detached external keyboard and started using buit-in keyboard, I was facing issue where multiple key press was not working.

This was happening because we were opening a file that does not exist. Even though we have try-catch block around keyboard handle, it was still giving error.

### What 
Add a check to only open keyboard file if it exists. If it does not exists, then exit the script with status code of 0.

### How to reproduce 
- Step the KeyboardChattering script as service with a external keyboard ID passed with `-k` option.
- Remove the external keyboard and restart the system
- Try to use the built-in keyboard in laptop.